### PR TITLE
Create district Issue

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/api/institute/service/v1/DistrictService.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/institute/service/v1/DistrictService.java
@@ -81,6 +81,13 @@ public class DistrictService {
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public Pair<DistrictEntity, InstituteEvent> createDistrict(District district) throws JsonProcessingException {
     var districtEntity = DistrictMapper.mapper.toModel(district);
+
+    districtEntity.getAddresses().stream().forEach(address -> {
+      RequestUtil.setAuditColumnsForAddress(address);
+      TransformUtil.uppercaseFields(address);
+      address.setDistrictEntity(districtEntity);
+    });
+
     TransformUtil.uppercaseFields(districtEntity);
     districtRepository.save(districtEntity);
     districtHistoryService.createDistrictHistory(districtEntity, district.getCreateUser());

--- a/api/src/test/java/ca/bc/gov/educ/api/institute/controller/v1/DistrictControllerTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/institute/controller/v1/DistrictControllerTest.java
@@ -297,6 +297,25 @@ public class DistrictControllerTest {
   }
 
   @Test
+  void testCreateDistrictWithAddress_GivenValidPayload_ShouldReturnStatusCreated() throws Exception {
+    var district = this.createDistrictData();
+    var addressEntity = this.createDistrictAddressData();
+    addressEntity.setCreateDate(null);
+    addressEntity.setUpdateDate(null);
+    district.getAddresses().add(addressEntity);
+    district.setCreateDate(null);
+    district.setUpdateDate(null);
+    this.mockMvc.perform(post(URL.BASE_URL_DISTRICT)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .content(asJsonString(district))
+                    .with(jwt().jwt((jwt) -> jwt.claim("scope", "WRITE_DISTRICT"))))
+            .andDo(print())
+            .andExpect(status().isCreated())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.displayName").value(district.getDisplayName()));
+  }
+
+  @Test
   void testCreateDistrict_GivenInvalidPayload_ShouldReturnStatusBadRequest() throws Exception {
     final var district = this.createDistrictData();
     district.setDistrictRegionCode("ABCD");


### PR DESCRIPTION
Fix for: [io.undertow.request] | [UT005023: Exception handling request to /api/v1/institute/district ] | java.lang.NullPointerException: Cannot invoke ca.bc.gov.educ.api.institute.model.v1.DistrictEntity.getDistrictId() because the return value of ca.bc.gov.educ.api.institute.model.v1.DistrictAddressEntity.getDistrictEntity() is null