### PR TITLE
Fix SCHOOL_MOVED event publishing

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/api/institute/service/v1/SchoolService.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/institute/service/v1/SchoolService.java
@@ -462,6 +462,7 @@ public class SchoolService {
     final InstituteEvent instituteEvent = EventUtil.createInstituteEvent(
         movedSchool.getUpdateUser(), movedSchool.getUpdateUser(),
         JsonUtil.getJsonStringFromObject(moveSchoolData), MOVE_SCHOOL, SCHOOL_MOVED);
+    instituteEventRepository.save(instituteEvent);
     return Pair.of(moveSchoolData, instituteEvent);
   }
 


### PR DESCRIPTION
Events for SCHOOL_MOVED were not being published. A null event id was to blame. Only events with an eventId are emitted.